### PR TITLE
Feature/remove dxa call endpoint

### DIFF
--- a/backend/endpoints/assistants.py
+++ b/backend/endpoints/assistants.py
@@ -78,32 +78,3 @@ async def check_assistant():
     except Exception as e:
         logger.error(f"Error checking assistant: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
-
-@router.post("/dxa-call")
-async def dxa_call(request: dict):
-    try:
-        # DXA呼び出しの処理を行う
-        question = request.get("question")
-        if not question:
-            raise HTTPException(status_code=400, detail="Missing question")
-
-        # DXA呼び出しの結果を取得
-        raw_answer = call_dxa_factory(question)
-
-        # スタイル情報を追加
-        response = {
-            "answer": raw_answer,
-            "style": {
-                "backgroundColor": "rgba(45, 55, 72, 0.95)",
-                "borderLeft": "4px solid",
-                "borderColor": "primary.main",
-                "boxShadow": "0 2px 4px rgba(0,0,0,0.2)",
-                "label": "DXA"
-            },
-            "is_function_call": True
-            }
-
-        return response
-    except Exception as e:
-        logger.error(f"Error in DXA call: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -398,25 +398,30 @@ function App() {
                       bgcolor: message.isUser 
                         ? 'primary.main'
                         : message.isDxaResponse 
-                          ? 'rgba(255, 223, 186, 0.95)' // Example color for DXA responses
+                          ? 'grey.300'
                           : 'background.paper',
-                      color: message.isUser ? 'primary.contrastText' : 'text.primary',
+                      color: message.isUser 
+                        ? 'primary.contrastText' 
+                        : message.isDxaResponse
+                          ? '#000000'  // DXAレスポンスの文字色を黒に
+                          : 'text.primary',
                       ...(message.isDxaResponse && {
                         borderLeft: '4px solid',
-                        borderColor: 'orange',
+                        borderColor: 'primary.main',
                         boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
                         position: 'relative',
+                        backgroundColor: '#e0e0e0',
                         '&::before': {
                           content: '"DXA"',
                           position: 'absolute',
-                          top: 8,
+                          bottom: 8,
                           right: 8,
                           fontSize: '0.75rem',
                           padding: '2px 6px',
                           borderRadius: '4px',
-                          backgroundColor: 'orange',
-                          color: 'white',
-                          opacity: 0.8
+                          backgroundColor: 'primary.main',
+                          color: 'primary.contrastText',
+                          opacity: 0.9
                         }
                       })
                     }}


### PR DESCRIPTION
## Changes
- Remove test-purpose `/dxa-call` endpoint
- DXA calls are now handled through the chat interface only

## Reason for Change
The `/dxa-call` endpoint was used for testing purposes but is no longer needed as all DXA functionality is now properly integrated into the chat interface.

## Testing
- Verified that removing the endpoint does not affect the main chat functionality
- Confirmed that DXA responses still work correctly through the chat interface
- No regression in existing features

## Impact
This change simplifies the codebase by removing unused code while maintaining all necessary functionality through the chat interface.