### PR TITLE
add: DXA Factory のレスポンスの型を定義

### DIFF
--- a/backend/endpoints/chat.py
+++ b/backend/endpoints/chat.py
@@ -21,6 +21,7 @@ class Message(BaseModel):
 class StreamingEvent:
     THINKING = "thinking"
     FUNCTION_CALL = "function_call"
+    DXA_FACTORY = "dxa_factory"
     COMPLETE = "complete"
 
 
@@ -204,7 +205,12 @@ async def stream_chat_response(message_content: str | list, thread_id: str, assi
                             has_dxa_response = True  # Set flag for DXA response
                             try:
                                 arg = json.loads(tool_call.function.arguments)
-                                answer = call_dxa_factory(arg['question'])
+                                dxa_response = call_dxa_factory(arg['question'])
+                                yield json.dumps({
+                                    "type": StreamingEvent.DXA_FACTORY,
+                                    "data": dxa_response
+                                }) + "\n"
+                                answer = dxa_response['answer']['response']['task_result']['content']
                                 tool_outputs.append({
                                     "tool_call_id": tool_call.id,
                                     "output": answer if answer else "該当する決算情報が見つかりませんでした。"

--- a/backend/services/openai.py
+++ b/backend/services/openai.py
@@ -64,7 +64,7 @@ def _generate_aiko_message(query):
         return f"request failed. status: {response.status_code}"
     data = response.json()
     logger.info(data)
-    return data['answer']['response']['task_result']['content']
+    return data
 
 
 def call_dxa_factory(question: str) -> str:
@@ -248,7 +248,7 @@ class Assistant:
                             try:
                                 arg = json.loads(tool.function.arguments)
                                 logger.info("Processing securities report question: %s", arg['question'])
-                                answer = call_dxa_factory(arg['question'])
+                                answer = call_dxa_factory(arg['question'])['answer']['response']['task_result']['content']
                                 if not answer:
                                     logger.warning("No answer found in securities report")
                                     answer = "申し訳ありません。該当する決算情報が見つかりませんでした。"

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { Message, ImageDetailLevel } from '../types';
+import { DxaResponse, Message, ImageDetailLevel } from '../types';
 
 export const useChat = () => {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -36,6 +36,13 @@ export const useChat = () => {
                 break;
               case 'function_call':
                 setThinkingText(event.data);
+                break;
+              case 'dxa_factory':
+                // レスポンス内容
+                const dxaResponse: DxaResponse = event.data;
+                console.log(dxaResponse);
+                // 回答
+                console.log(dxaResponse.answer.response.task_result.content);
                 break;
               case 'complete':
                 console.log('Complete event data:', event.data);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -42,4 +42,42 @@ export interface RunStep {
   };
 }
 
-export type ImageDetailLevel = 'low' | 'high' | 'auto'; 
+export type ImageDetailLevel = 'low' | 'high' | 'auto';
+
+export interface DxaResponse {
+  status: string;
+  answer: DxaAnswer;
+}
+
+export interface DxaAnswer {
+  response: DxaAnswerResponse;
+  success: boolean;
+  task_id: string;
+}
+
+export interface DxaAnswerResponse {
+  main_task: string;
+  ooda_task_id: string;
+  substasks: DxaTask[];
+  task_result: DxaTaskResult;
+}
+
+export interface DxaTask {
+  status: string;
+  task: string;
+  task_id: string;
+  task_result: DxaTaskResult;
+}
+
+export interface DxaTaskResult {
+  citations: DxaTaskCitation[];
+  content: string;
+}
+
+export interface DxaTaskCitation {
+  file_path: string;
+  image_src: string; // 現状nullが返却されている、おそらくstring
+  page_index: number;
+  source: string;
+  type: string;
+}


### PR DESCRIPTION
# 概要
- チャットAPIのレスポンスの内、DXA Factoryのレスポンスの場合にtypeをdxa_factoryで返却
- フロント側でDXA Factoryのレスポンスのinterfaceを定義
